### PR TITLE
feat(core): add test mode and expand commit generator context

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.analysis.extraPaths": [
+        "./app"
+    ]
+}

--- a/app/dify/models.py
+++ b/app/dify/models.py
@@ -6,7 +6,7 @@
 @Desc    :
 """
 from decimal import Decimal
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import Any, Dict, List, Optional, Union
 from typing import Type, Literal
 
@@ -25,8 +25,18 @@ class FilesUploadResponse(BaseModel):
     created_at: int
 
 
+class ForcedCommand(StrEnum):
+    ANY = "Any"
+    COMMIT_MESSAGE_GENERATION = "CommitMessageGeneration"
+    AUTO_TRANSLATION = "AutoTranslation"
+    TEST = "Test"
+
+
 FILE_TYPE = Union[str, Literal["document", "image", "audio", "video", "custom"]]
-FORCED_COMMAND_TYPE = Union[str, Literal["Any", "CommitMessageGeneration", "AutoTranslation"]]
+
+FORCED_COMMAND_TYPE = Union[
+    str, ForcedCommand, Literal["Any", "CommitMessageGeneration", "AutoTranslation", "Test"]
+]
 
 
 class WorkflowFileInputBody(BaseModel):

--- a/app/main.py
+++ b/app/main.py
@@ -60,6 +60,9 @@ def main() -> None:
     if settings.ENABLE_DEV_MODE:
         logger.warning("🪄 开发模式已启动")
 
+    if settings.ENABLE_TEST_MODE:
+        logger.warning("🪄 测试模式已启动")
+
     # 定期清理旧的下载图片（每次重启时都尝试清理）
     with suppress(Exception):
         cleanup_old_photos(max_age_hours=24)

--- a/app/mybot/services/dify_service.py
+++ b/app/mybot/services/dify_service.py
@@ -32,10 +32,11 @@ async def invoke_model_blocking(
     result_text = result.data.outputs.answer
 
     with suppress(Exception):
-        outputs_json = json.dumps(
-            result.data.outputs.model_dump(mode="json"), indent=2, ensure_ascii=False
-        )
-        logger.debug(f"LLM Result: \n{outputs_json}")
+        if settings.ENABLE_TEST_MODE:
+            outputs_json = json.dumps(
+                result.data.outputs.model_dump(mode="json"), indent=2, ensure_ascii=False
+            )
+            logger.debug(f"LLM Result: \n{outputs_json}")
 
     return result_text
 

--- a/app/mybot/services/instant_view_service.py
+++ b/app/mybot/services/instant_view_service.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+"""
+@Time    : 2025/7/12 10:00
+@Author  : QIN2DIM
+@GitHub  : https://github.com/QIN2DIM
+@Desc    : Service for handling Instant View rendering.
+"""
+from typing import Dict, Any, Optional
+
+from loguru import logger
+from telegram import Bot
+from telegram.constants import ParseMode
+
+from dify.models import AnswerType
+from plugins.instant_view_generator.node import create_instant_view
+
+
+async def render_instant_view(
+    bot: Bot,
+    chat_id: int,
+    message_id: int,
+    content: str,
+    extras: Dict[str, Any],
+    final_type: str,
+    title: Optional[str] = None,
+    input_format: ParseMode = ParseMode.MARKDOWN,
+) -> bool:
+    """
+    Render content as Instant View
+
+    Args:
+        input_format:
+        bot: Telegram bot instance
+        chat_id: Chat ID
+        message_id: Message ID to edit
+        content: Content to render
+        extras: Extra data containing photo_links, place_name, etc.
+        final_type: Answer type
+        title: Optional title for instant view
+
+    Returns:
+        bool: True if successful, False otherwise
+    """
+    try:
+        instant_view_content = content
+
+        # If it's geolocation identification task with photos, integrate them into Instant View content
+        photo_links = extras.get("photo_links", [])
+        place_name = extras.get("place_name", "")
+        if final_type == AnswerType.GEOLOCATION_IDENTIFICATION and photo_links:
+            # Add photo links to Markdown content
+            instant_view_content += "\n\n"
+            if place_name:
+                instant_view_content += f"## {place_name}\n\n"
+
+            # Add images to Markdown
+            for i, photo_url in enumerate(photo_links):
+                if i == 0:
+                    instant_view_content += f"![Street View]({photo_url})\n\n"
+                else:
+                    instant_view_content += f"![Street View {i+1}]({photo_url})\n\n"
+
+        response = await create_instant_view(
+            content=instant_view_content,
+            input_format="HTML" if input_format in [ParseMode.HTML] else "Markdown",
+            title=title or extras.get("title"),
+        )
+
+        if response.success:
+            await bot.edit_message_text(
+                chat_id=chat_id,
+                message_id=message_id,
+                parse_mode=ParseMode.HTML,
+                text=response.instant_view_content.strip(),
+            )
+            return True
+        else:
+            logger.warning(f"Failed to create instant view: {response}")
+            return False
+
+    except Exception as e:
+        logger.error(f"Failed to render instant view: {e}")
+        return False
+
+
+async def try_send_as_instant_view(
+    bot: Bot,
+    chat_id: int,
+    message_id: int,
+    content: str,
+    extras: Dict[str, Any] = None,
+    final_type: str = "",
+    title: Optional[str] = None,
+    parse_mode: ParseMode = ParseMode.HTML,
+) -> bool:
+    """
+    Try to send content as Instant View when a regular message fails
+
+    Args:
+        parse_mode:
+        bot: Telegram bot instance
+        chat_id: Chat ID
+        message_id: Message ID to edit
+        content: Content to send
+        extras: Extra data, defaults to empty dict
+        final_type: Answer type
+        title: Optional title for instant view
+
+    Returns:
+        bool: True if successful, False otherwise
+    """
+    extras = extras or {}
+
+    logger.info("Attempting to send content as Instant View due to message length limit")
+    return await render_instant_view(
+        bot=bot,
+        chat_id=chat_id,
+        message_id=message_id,
+        content=content,
+        extras=extras,
+        final_type=final_type,
+        title=title,
+        input_format=parse_mode,
+    )

--- a/app/mybot/services/response_service.py
+++ b/app/mybot/services/response_service.py
@@ -8,17 +8,59 @@
 import json
 import time
 from contextlib import suppress
-from typing import AsyncGenerator, Dict, Any
+from typing import AsyncGenerator, Dict, Any, Optional
 
+import telegram.error
 from loguru import logger
-from telegram import Update, InputMediaPhoto
+from telegram import Update, InputMediaPhoto, Message
 from telegram.constants import ParseMode
 from telegram.ext import ContextTypes
 
 from dify.models import AnswerType
 from models import Interaction, TaskType, AGENT_STRATEGY_TYPE, AgentStrategy
-from plugins.instant_view_generator.node import create_instant_view
+from mybot.services.instant_view_service import render_instant_view, try_send_as_instant_view
 from settings import settings
+
+# Constants
+LOADING_PLACEHOLDER = "🔄 Loading..."
+INITIAL_PLANNING_TEXT = "🤔 Planning..."
+ERROR_MESSAGE = "抱歉，处理过程中遇到问题，请稍后再试。"
+FAILURE_MESSAGE = "抱歉，处理失败。"
+AGENT_LOG_UPDATE_INTERVAL = 1.5
+MEDIA_GROUP_LIMIT = 9
+
+
+async def _handle_message_too_long_fallback(
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    content: str,
+    reply_to_message_id: Optional[int] = None,
+    extras: Optional[Dict[str, Any]] = None,
+    final_type: str = "",
+    title: Optional[str] = None,
+    parse_mode: Optional[ParseMode] = None,
+) -> bool:
+    """Handle message too long error by creating placeholder and using Instant View"""
+    try:
+        # Create placeholder message
+        placeholder_message = await context.bot.send_message(
+            chat_id=chat_id, text=LOADING_PLACEHOLDER, reply_to_message_id=reply_to_message_id
+        )
+
+        # Use Instant View to edit placeholder
+        return await try_send_as_instant_view(
+            bot=context.bot,
+            chat_id=chat_id,
+            message_id=placeholder_message.message_id,
+            content=content,
+            extras=extras or {},
+            final_type=final_type,
+            title=title,
+            parse_mode=parse_mode,
+        )
+    except Exception as e:
+        logger.error(f"Failed to handle message too long fallback: {e}")
+        return False
 
 
 async def _send_message(
@@ -27,7 +69,9 @@ async def _send_message(
     text: str,
     reply_to_message_id: int | None = None,
 ) -> bool:
-    """发送消息的辅助函数，优雅降级处理 Markdown 格式错误"""
+    """Send message with graceful fallback for formatting errors and long messages"""
+
+    # Try with different parse modes
     for parse_mode in settings.pending_parse_mode:
         try:
             await context.bot.send_message(
@@ -37,17 +81,35 @@ async def _send_message(
                 parse_mode=parse_mode,
             )
             return True
+        except telegram.error.BadRequest as err:
+            if "Message_too_long" in str(err).lower():
+                logger.info(f"Message too long ({parse_mode}), switching to Instant View")
+                return await _handle_message_too_long_fallback(
+                    context, chat_id, text, reply_to_message_id, parse_mode=parse_mode
+                )
+            else:
+                logger.error(f"Failed to send message({parse_mode}): {err}")
         except Exception as err:
-            logger.error(f"Failed to send final message({parse_mode}): {err}")
+            logger.error(f"Failed to send message({parse_mode}): {err}")
 
+    # Final fallback without parse mode
     try:
         await context.bot.send_message(
             chat_id=chat_id, text=text, reply_to_message_id=reply_to_message_id
         )
         return True
+    except telegram.error.BadRequest as err:
+        if "Message_too_long" in str(err).lower():
+            logger.info("Message too long (no parse mode), trying Instant View as final fallback")
+            return await _handle_message_too_long_fallback(
+                context, chat_id, text, reply_to_message_id
+            )
+        else:
+            logger.error(f"Failed to send message: {err}")
     except Exception as e2:
         logger.error(f"Failed to send message: {e2}")
-        return False
+
+    return False
 
 
 async def _send_photo_with_caption(
@@ -55,9 +117,9 @@ async def _send_photo_with_caption(
     chat_id: int,
     photo_url: str,
     caption: str,
-    reply_to_message_id: int | None = None,
+    reply_to_message_id: Optional[int] = None,
 ) -> bool:
-    """发送带标题的图片消息"""
+    """Send photo with caption, trying multiple parse modes"""
     for parse_mode in settings.pending_parse_mode:
         try:
             await context.bot.send_photo(
@@ -71,6 +133,7 @@ async def _send_photo_with_caption(
         except Exception as err:
             logger.error(f"Failed to send photo with caption({parse_mode}): {err}")
 
+    # Final fallback without parse mode
     try:
         await context.bot.send_photo(
             chat_id=chat_id,
@@ -89,55 +152,224 @@ async def _send_media_group_with_caption(
     chat_id: int,
     photo_urls: list[str],
     caption: str,
-    reply_to_message_id: int | None = None,
+    reply_to_message_id: Optional[int] = None,
 ) -> bool:
-    """发送多张图片+文字的媒体组消息"""
+    """Send media group with caption on first photo"""
     if not photo_urls:
         return False
 
-    parse_mode = ParseMode.HTML
-
-    # 构造媒体组：第一张图片包含文字，其他图片不包含文字
-    media_group = []
-
     try:
-
+        media_group = []
         for i, photo_url in enumerate(photo_urls):
             if i == 0:
-                # 第一张图片包含完整的文字说明
+                # First photo includes caption
                 media_group.append(
-                    InputMediaPhoto(media=photo_url, caption=caption, parse_mode=parse_mode)
+                    InputMediaPhoto(media=photo_url, caption=caption, parse_mode=ParseMode.HTML)
                 )
             else:
-                # 其他图片不包含文字
                 media_group.append(InputMediaPhoto(media=photo_url))
 
         await context.bot.send_media_group(
-            chat_id=chat_id, media=media_group[:9], reply_to_message_id=reply_to_message_id
+            chat_id=chat_id,
+            media=media_group[:MEDIA_GROUP_LIMIT],
+            reply_to_message_id=reply_to_message_id,
         )
         return True
     except Exception as err:
-        logger.exception(f"Failed to send media group({parse_mode}): {err}")
+        logger.exception(f"Failed to send media group: {err}")
+        return False
 
-    return False
+
+def _parse_agent_log_data(
+    agent_data: Dict[str, Any], agent_strategy_name: AGENT_STRATEGY_TYPE
+) -> Dict[str, Any]:
+    """Parse agent log data based on strategy type"""
+    parsed_data = {
+        "action": "",
+        "thought": "",
+        "output_text": "",
+        "tool_input": [],
+        "tool_call_name": "",
+        "tool_response": "",
+        "tool_call_input": {},
+    }
+
+    if agent_strategy_name == AgentStrategy.REACT:
+        parsed_data["action"] = agent_data.get("action", agent_data.get("action_name", ""))
+        agent_data_json = json.dumps(agent_data, indent=2, ensure_ascii=False)
+        parsed_data["thought"] = f'<pre><code class="language-json">{agent_data_json}</code></pre>'
+
+    elif agent_strategy_name == AgentStrategy.FUNCTION_CALLING:
+        if output_pending := agent_data.get("output"):
+            if isinstance(output_pending, str):
+                parsed_data["output_text"] = output_pending
+            elif isinstance(output_pending, dict):
+                parsed_data["output_text"] = output_pending.get("llm_response", "")
+
+        parsed_data["tool_input"] = agent_data.get("tool_input", [])
+        parsed_data["tool_call_input"] = agent_data.get("tool_call_input", {})
+        parsed_data["tool_call_name"] = agent_data.get("tool_call_name", "")
+        parsed_data["tool_response"] = agent_data.get("tool_response", "")
+
+    return parsed_data
+
+
+def _format_agent_log(parsed_data: Dict[str, Any]) -> str:
+    """Format parsed agent log data into display text"""
+    agent_log_parts = []
+
+    if action := parsed_data["action"]:
+        agent_log_parts.append(f"<blockquote>Agent: {action}</blockquote>")
+
+    if thought := parsed_data["thought"]:
+        agent_log_parts.append(thought)
+
+    if output_text := parsed_data["output_text"]:
+        agent_log_parts.append(output_text)
+
+    if tool_input := parsed_data["tool_input"]:
+        for t in tool_input:
+            if isinstance(t, dict) and "args" in t and "name" in t:
+                block_language = t.get("args", {}).get("language", "json")
+                tool_args_content = json.dumps(t["args"], indent=2, ensure_ascii=False)
+                agent_log_parts.append(f"<blockquote>ToolUse: {t['name']}</blockquote>")
+                agent_log_parts.append(
+                    f'<pre><code class="language-{block_language}">{tool_args_content}</code></pre>'
+                )
+
+    if tool_call_name := parsed_data["tool_call_name"]:
+        agent_log_parts.append(f"<blockquote>ToolUse: {tool_call_name}</blockquote>")
+
+    if tool_call_input := parsed_data["tool_call_input"]:
+        block_language = tool_call_input.get("language", "json")
+        tool_args = json.dumps(tool_call_input, indent=2, ensure_ascii=False)
+        agent_log_parts.append(
+            f'<pre><code class="language-{block_language}">{tool_args}</code></pre>'
+        )
+
+    if tool_response := parsed_data["tool_response"]:
+        agent_log_parts.append(f'<pre><code class="language-json">{tool_response}</code></pre>')
+
+    return "\n\n".join(agent_log_parts)
+
+
+async def _update_progress_message(
+    context: ContextTypes.DEFAULT_TYPE, chat_id: int, message_id: int, text: str
+) -> None:
+    """Update progress message with error handling"""
+    try:
+        await context.bot.edit_message_text(
+            chat_id=chat_id, message_id=message_id, text=text, parse_mode=ParseMode.HTML
+        )
+    except Exception as err:
+        logger.error(f"Failed to update progress message: {err}")
+
+
+async def _handle_final_answer_rendering(
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    initial_message: Message,
+    final_answer: str,
+    extras: Dict[str, Any],
+    final_type: str,
+) -> Optional[int]:
+    """Handle final answer rendering with fallback strategies"""
+    # Try Instant View if explicitly requested
+    if extras.get("is_instant_view"):
+        success = await render_instant_view(
+            bot=context.bot,
+            chat_id=chat_id,
+            message_id=initial_message.message_id,
+            content=final_answer,
+            extras=extras,
+            final_type=final_type,
+            title=extras.get("title"),
+        )
+        if success:
+            return initial_message.message_id
+
+    # Try general rich text rendering
+    for parse_mode in settings.pending_parse_mode:
+        try:
+            await context.bot.edit_message_text(
+                chat_id=chat_id,
+                message_id=initial_message.message_id,
+                text=final_answer,
+                parse_mode=parse_mode,
+            )
+            return initial_message.message_id
+        except telegram.error.BadRequest as err:
+            if "Message_too_long" in str(err):
+                logger.info("Message too long, switching to Instant View")
+                success = await try_send_as_instant_view(
+                    bot=context.bot,
+                    chat_id=chat_id,
+                    message_id=initial_message.message_id,
+                    content=final_answer,
+                    extras=extras,
+                    final_type=final_type,
+                    title=extras.get("title"),
+                    parse_mode=parse_mode,
+                )
+                if success:
+                    return initial_message.message_id
+                break
+        except Exception as err:
+            logger.exception(f"Failed to send final message({parse_mode}): {err}")
+
+    # Final fallback to Instant View
+    logger.warning("All parse modes failed, trying Instant View as fallback")
+    success = await try_send_as_instant_view(
+        bot=context.bot,
+        chat_id=chat_id,
+        message_id=initial_message.message_id,
+        content=final_answer,
+        extras=extras,
+        final_type=final_type,
+        title=extras.get("title"),
+    )
+    return initial_message.message_id if success else None
+
+
+async def _send_street_view_images(
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    photo_links: list[str],
+    place_name: str,
+    reply_to_message_id: Optional[int] = None,
+) -> None:
+    """Send street view images as supplementary information"""
+    if not photo_links:
+        return
+
+    caption = f"<code>{place_name.strip()}</code>" if place_name else "Street View"
+
+    if len(photo_links) > 1:
+        await _send_media_group_with_caption(
+            context, chat_id, photo_links, caption, reply_to_message_id=reply_to_message_id
+        )
+    else:
+        await _send_photo_with_caption(
+            context, chat_id, photo_links[0], caption, reply_to_message_id=reply_to_message_id
+        )
 
 
 async def send_standard_response(
     update: Update, context: ContextTypes.DEFAULT_TYPE, interaction: Interaction, result_text: str
 ):
-    """为 blocking 模式发送标准回复"""
+    """Send standard response for blocking mode"""
     chat_id = update.effective_chat.id
     trigger_message = update.effective_message
 
     if interaction.task_type in [TaskType.MENTION, TaskType.MENTION_WITH_REPLY, TaskType.REPLAY]:
-        # 优先直接回复
+        # Try direct reply first
         sent = await _send_message(
             context, chat_id, result_text, reply_to_message_id=trigger_message.message_id
         )
         if sent:
             return
 
-        # 失败则尝试 @用户
+        # Fallback to mention user
         user_mention = "User"
         if trigger_message.from_user:
             user_mention = trigger_message.from_user.mention_html()
@@ -154,259 +386,193 @@ async def send_streaming_response(
     interaction: Interaction,
     streaming_generator: AsyncGenerator[Dict[str, Any], None],
 ):
-    """处理流式响应，发送并编辑消息"""
+    """Handle streaming response with live updates"""
     chat = update.effective_chat
     trigger_message = update.effective_message
     initial_message = None
 
     try:
-        # 创建初始消息
-        initial_text = "🤔 Planning..."
+        # Create an initial message
         initial_message = await context.bot.send_message(
             chat_id=chat.id,
-            text=initial_text,
+            text=INITIAL_PLANNING_TEXT,
             reply_to_message_id=(
                 trigger_message.message_id if interaction.task_type != TaskType.AUTO else None
             ),
         )
 
-        final_result: dict | None = None
-        agent_strategy_name: AGENT_STRATEGY_TYPE = ""
-        last_edit_time = time.time()
+        final_result = await _process_streaming_chunks(
+            context, chat.id, initial_message, streaming_generator
+        )
 
-        async for chunk in streaming_generator:
-            if not chunk or not isinstance(chunk, dict) or not (event := chunk.get("event")):
-                continue
-
-            chunk_data = chunk.get("data", {})
-            node_type = chunk_data.get("node_type", "")
-            node_title = chunk_data.get("title", "")
-            node_index = chunk_data.get("index", 0)
-
-            # logger.debug(json.dumps(chunk, indent=2, ensure_ascii=False))
-
-            if event == "workflow_finished":
-                final_result = chunk_data.get('outputs', {})
-                break
-            elif event in ["node_started"]:
-                key_progress_text = ""
-                if agent_strategy := chunk_data.get("agent_strategy", {}):
-                    agent_strategy_name = agent_strategy.get("name", "")
-                if node_type in ["llm", "agent"] and node_title:
-                    key_progress_text = f"<blockquote>{node_title}</blockquote>"
-                elif node_type in ["tool"] and node_title:
-                    # bypass flood
-                    if node_index > 3:
-                        key_progress_text = f"<blockquote>✨ 工具使用：{node_title}</blockquote>"
-                if key_progress_text:
-                    try:
-                        await context.bot.edit_message_text(
-                            chat_id=chat.id,
-                            message_id=initial_message.message_id,
-                            text=key_progress_text,
-                            parse_mode=ParseMode.HTML,
-                        )
-                    except Exception as err:
-                        logger.error(f"Failed to edit node's title: {err}")
-            elif event == "agent_log":
-                _agent_log = ""
-                agent_log_parts = []
-
-                # ReAct 结构化日志
-                thought = ""
-                action = ""
-
-                # function_calling 结构化日志
-                output_text = ""
-                tool_input = []
-                tool_call_name = ""
-                tool_response = ""
-                tool_call_input = {}
-
-                # == 填充模板 == #
-                if agent_data := chunk_data.get("data", {}):
-                    # 适配的 Agent(ReAct) Node 的 agent_log 协议规范
-                    if agent_strategy_name == AgentStrategy.REACT:
-                        action = agent_data.get("action", agent_data.get("action_name", ""))
-                        agent_data_json = json.dumps(agent_data, indent=2, ensure_ascii=False)
-                        thought = f'<pre><code class="language-json">{agent_data_json}</code></pre>'
-
-                    # 适配 function_calling agent_strategy 协议规范
-                    elif agent_strategy_name == AgentStrategy.FUNCTION_CALLING:
-                        if output_pending := agent_data.get("output"):
-                            if isinstance(output_pending, str):
-                                output_text = output_pending
-                            if isinstance(output_pending, dict):
-                                output_text = output_pending.get("llm_response", "")
-                        tool_input = agent_data.get("tool_input", [])
-                        tool_call_input = agent_data.get("tool_call_input", {})
-                        tool_call_name = agent_data.get("tool_call_name", "")
-                        tool_response = agent_data.get("tool_response", "")
-                elif chunk_data.get("status", "") == "start":
-                    if agent_strategy_name == AgentStrategy.FUNCTION_CALLING:
-                        action = "🤔 Thinking..."
-
-                # == 解析模板 == #
-                if action:
-                    agent_log_parts.append(f"<blockquote>Agent: {action}</blockquote>")
-                if thought:
-                    agent_log_parts.append(thought)
-                if output_text:
-                    agent_log_parts.append(output_text)
-                if tool_input:
-                    for t in tool_input:
-                        if isinstance(t, dict) and "args" in t and "name" in t:
-                            block_language = t.get("args", {}).get("language", "json")
-                            tool_args_content = json.dumps(t["args"], indent=2, ensure_ascii=False)
-                            agent_log_parts.append(f"<blockquote>ToolUse: {t['name']}</blockquote>")
-                            agent_log_parts.append(
-                                f'<pre><code class="language-{block_language}">{tool_args_content}</code></pre>'
-                            )
-                if tool_call_name:
-                    agent_log_parts.append(f"<blockquote>ToolUse: {tool_call_name}</blockquote>")
-                if tool_call_input:
-                    block_language = tool_call_input.get("language", "json")
-                    tool_args = json.dumps(tool_call_input, indent=2, ensure_ascii=False)
-                    agent_log_parts.append(
-                        f'<pre><code class="language-{block_language}">{tool_args}</code></pre>'
-                    )
-                if tool_response:
-                    agent_log_parts.append(
-                        f'<pre><code class="language-json">{tool_response}</code></pre>'
-                    )
-
-                _agent_log = "\n\n".join(agent_log_parts)
-
-                if _agent_log:
-                    try:
-                        now = time.time()
-                        if now - last_edit_time > 1.5:
-                            await context.bot.edit_message_text(
-                                chat_id=chat.id,
-                                message_id=initial_message.message_id,
-                                text=_agent_log,
-                                parse_mode=ParseMode.HTML,
-                            )
-                            last_edit_time = now
-                    except Exception as err:
-                        logger.error(f"Failed to edit agent log: {err}")
-
-        # 输出响应日志
-        with suppress(Exception):
-            if final_result:
-                outputs_json = json.dumps(final_result, indent=2, ensure_ascii=False)
-                logger.debug(f"LLM Result: \n{outputs_json}")
-            else:
-                logger.warning("No final result")
-
-        # 更新为最终结果
-        final_answer_message_id = None
-        if final_result and (final_answer := final_result.get(settings.BOT_OUTPUTS_ANSWER_KEY, '')):
-            final_type = final_result.get(settings.BOT_OUTPUTS_TYPE_KEY, "")
-            extras = final_result.get(settings.BOT_OUTPUTS_EXTRAS_KEY, {})
-
-            # == RENDER 1: Instant View == #
-            # 期望 instant_view 都使用标准的 Markdown 语法表达，而非 HTML
-            if extras.get("is_instant_view"):
-                try:
-                    instant_view_content = final_answer
-
-                    # 如果是地理位置识别任务且有图片，将图片整合到 Instant View 内容中
-                    photo_links = extras.get("photo_links", [])
-                    place_name = extras.get("place_name", "")
-                    if final_type == AnswerType.GEOLOCATION_IDENTIFICATION and photo_links:
-                        # 将图片链接添加到 Markdown 内容中
-                        instant_view_content += "\n\n"
-                        if place_name:
-                            instant_view_content += f"## {place_name}\n\n"
-
-                        # 添加图片到 Markdown 中
-                        for i, photo_url in enumerate(photo_links):
-                            if i == 0:
-                                instant_view_content += f"![Street View]({photo_url})\n\n"
-                            else:
-                                instant_view_content += f"![Street View {i+1}]({photo_url})\n\n"
-                    response = await create_instant_view(
-                        content=instant_view_content,
-                        input_format="Markdown",
-                        title=extras.get("title"),
-                    )
-                    if response.success:
-                        await context.bot.edit_message_text(
-                            chat_id=chat.id,
-                            message_id=initial_message.message_id,
-                            parse_mode=ParseMode.HTML,
-                            text=response.instant_view_content.strip(),
-                        )
-                        return
-                except Exception as send_error:
-                    logger.error(f"发送错误回复失败: {send_error}")
-                    # Instant View 渲染失败，将继续执行后续的通用渲染和街景图片发送逻辑作为兜底
-
-            # == RENDER 2: General RichText == #
-            # 更新初始消息为最终答案
-            for parse_mode in settings.pending_parse_mode:
-                try:
-                    await context.bot.edit_message_text(
-                        chat_id=chat.id,
-                        message_id=initial_message.message_id,
-                        text=final_answer,
-                        parse_mode=parse_mode,
-                    )
-                    # 记录最终答案消息的 ID，用于后续街景图片引用
-                    final_answer_message_id = initial_message.message_id
-                    break
-                except Exception as err:
-                    logger.exception(f"Failed to send final message({parse_mode}): {err}")
-
-            # == RENDER 3: Street View Images == #
-            # 如果是地理位置识别任务且有图片，发送额外的街景图片作为补充
-            photo_links = extras.get("photo_links", [])
-            place_name = extras.get("place_name", "")
-            caption = f"<code>{place_name.strip()}</code>" if place_name else "Street View"
-            if final_type == AnswerType.GEOLOCATION_IDENTIFICATION and photo_links:
-                # 确定街景图片引用的消息 ID：优先引用机器人自己的最终答案消息，没有的话再引用用户消息
-                street_view_reply_id = None
-                if interaction.task_type != TaskType.AUTO:
-                    # 优先引用机器人自己发送的最终答案消息
-                    street_view_reply_id = final_answer_message_id or trigger_message.message_id
-
-                # 发送街景图片作为补充信息
-                if len(photo_links) > 1:
-                    # 多张图片：使用 send_media_group
-                    await _send_media_group_with_caption(
-                        context,
-                        chat.id,
-                        photo_links,
-                        caption,
-                        reply_to_message_id=street_view_reply_id,
-                    )
-                else:
-                    # 单张图片：使用 send_photo
-                    await _send_photo_with_caption(
-                        context,
-                        chat.id,
-                        photo_links[0],
-                        caption,
-                        reply_to_message_id=street_view_reply_id,
-                    )
-
-        else:
-            await context.bot.edit_message_text(
-                chat_id=chat.id, message_id=initial_message.message_id, text="抱歉，处理失败。"
-            )
+        await _handle_final_result(
+            context, chat, initial_message, final_result, interaction, trigger_message
+        )
 
     except Exception as e:
         logger.exception(f"Streaming response error: {e}")
-        error_message = "抱歉，处理过程中遇到问题，请稍后再试。"
-        if initial_message:
-            try:
-                await context.bot.edit_message_text(
-                    chat_id=chat.id, message_id=initial_message.message_id, text=error_message
-                )
-            except Exception as e2:
-                logger.error(f"Failed to edit message to error: {e2}")
-        else:
-            await _send_message(
-                context, chat.id, error_message, reply_to_message_id=trigger_message.message_id
+        await _handle_streaming_error(context, chat.id, initial_message, trigger_message)
+
+
+async def _process_streaming_chunks(
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    initial_message: Message,
+    streaming_generator: AsyncGenerator[Dict[str, Any], None],
+) -> Optional[Dict[str, Any]]:
+    """Process streaming chunks and update progress"""
+    final_result = None
+    agent_strategy_name = ""
+    last_edit_time = time.time()
+
+    async for chunk in streaming_generator:
+        if not chunk or not isinstance(chunk, dict) or not (event := chunk.get("event")):
+            continue
+
+        chunk_data = chunk.get("data", {})
+
+        if event == "workflow_finished":
+            final_result = chunk_data.get('outputs', {})
+            break
+
+        elif event == "node_started":
+            await _handle_node_started(
+                context, chat_id, initial_message, chunk_data, agent_strategy_name
             )
+
+        elif event == "agent_log":
+            agent_strategy_name = await _handle_agent_log(
+                context, chat_id, initial_message, chunk_data, agent_strategy_name, last_edit_time
+            )
+            last_edit_time = time.time()
+
+    return final_result
+
+
+async def _handle_node_started(
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    initial_message: Message,
+    chunk_data: Dict[str, Any],
+    agent_strategy_name: str,
+) -> str:
+    """Handle node_started event"""
+    node_type = chunk_data.get("node_type", "")
+    node_title = chunk_data.get("title", "")
+    node_index = chunk_data.get("index", 0)
+
+    if agent_strategy := chunk_data.get("agent_strategy", {}):
+        agent_strategy_name = agent_strategy.get("name", "")
+
+    key_progress_text = ""
+    if node_type in ["llm", "agent"] and node_title:
+        key_progress_text = f"<blockquote>{node_title}</blockquote>"
+    elif node_type == "tool" and node_title and node_index > 3:
+        key_progress_text = f"<blockquote>✨ 工具使用：{node_title}</blockquote>"
+
+    if key_progress_text:
+        await _update_progress_message(
+            context, chat_id, initial_message.message_id, key_progress_text
+        )
+
+    return agent_strategy_name
+
+
+async def _handle_agent_log(
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    initial_message: Message,
+    chunk_data: Dict[str, Any],
+    agent_strategy_name: str,
+    last_edit_time: float,
+) -> str:
+    """Handle agent_log event"""
+    if agent_data := chunk_data.get("data", {}):
+        parsed_data = _parse_agent_log_data(agent_data, agent_strategy_name)
+    elif (
+        chunk_data.get("status") == "start"
+        and agent_strategy_name == AgentStrategy.FUNCTION_CALLING
+    ):
+        parsed_data = {"action": "🤔 Thinking..."}
+    else:
+        return agent_strategy_name
+
+    agent_log_text = _format_agent_log(parsed_data)
+
+    if agent_log_text:
+        now = time.time()
+        if now - last_edit_time > AGENT_LOG_UPDATE_INTERVAL:
+            await _update_progress_message(
+                context, chat_id, initial_message.message_id, agent_log_text
+            )
+
+    return agent_strategy_name
+
+
+async def _handle_final_result(
+    context: ContextTypes.DEFAULT_TYPE,
+    chat: Any,
+    initial_message: Message,
+    final_result: Optional[Dict[str, Any]],
+    interaction: Interaction,
+    trigger_message: Message,
+) -> None:
+    """Handle final result rendering and supplementary content"""
+    # Log the result
+    with suppress(Exception):
+        if final_result:
+            outputs_json = json.dumps(final_result, indent=2, ensure_ascii=False)
+            logger.debug(f"LLM Result: \n{outputs_json}")
+        else:
+            logger.warning("No final result")
+
+    if not final_result or not (
+        final_answer := final_result.get(settings.BOT_OUTPUTS_ANSWER_KEY, '')
+    ):
+        await context.bot.edit_message_text(
+            chat_id=chat.id, message_id=initial_message.message_id, text=FAILURE_MESSAGE
+        )
+        return
+
+    final_type = final_result.get(settings.BOT_OUTPUTS_TYPE_KEY, "")
+    extras = final_result.get(settings.BOT_OUTPUTS_EXTRAS_KEY, {})
+
+    # Render final answer
+    final_answer_message_id = await _handle_final_answer_rendering(
+        context, chat.id, initial_message, final_answer, extras, final_type
+    )
+
+    # Send supplementary street view images if applicable
+    if final_type == AnswerType.GEOLOCATION_IDENTIFICATION:
+        photo_links = extras.get("photo_links", [])
+        place_name = extras.get("place_name", "")
+
+        if photo_links:
+            # Determine reply target
+            street_view_reply_id = None
+            if interaction.task_type != TaskType.AUTO:
+                street_view_reply_id = final_answer_message_id or trigger_message.message_id
+
+            await _send_street_view_images(
+                context, chat.id, photo_links, place_name, reply_to_message_id=street_view_reply_id
+            )
+
+
+async def _handle_streaming_error(
+    context: ContextTypes.DEFAULT_TYPE,
+    chat_id: int,
+    initial_message: Optional[Message],
+    trigger_message: Message,
+) -> None:
+    """Handle streaming errors gracefully"""
+    if initial_message:
+        try:
+            await context.bot.edit_message_text(
+                chat_id=chat_id, message_id=initial_message.message_id, text=ERROR_MESSAGE
+            )
+        except Exception as e2:
+            logger.error(f"Failed to edit message to error: {e2}")
+    else:
+        await _send_message(
+            context, chat_id, ERROR_MESSAGE, reply_to_message_id=trigger_message.message_id
+        )

--- a/app/plugins/commit_message_generator/node.py
+++ b/app/plugins/commit_message_generator/node.py
@@ -15,9 +15,9 @@ project_root = Path(__file__).parent.parent.parent
 if str(project_root) not in sys.path:
     sys.path.insert(0, str(project_root))
 
-from settings import LOG_DIR
-from utils import init_log
-from dify.workflow_tool import invoke_commit_message_generation
+from settings import LOG_DIR  # noqa: E402
+from utils import init_log  # noqa: E402
+from dify.workflow_tool import invoke_commit_message_generation  # noqa: E402
 
 init_log(
     runtime=LOG_DIR.joinpath("runtime.log"),
@@ -41,8 +41,8 @@ Generate a git commit message for the following changes.
 Provide the commit message as a single JSON object, following the rules and format specified in the system instructions. Do not add any text before or after the JSON object.
 """
 
-# 上下文最大长度（字符数），16k ~= 16384
-MAX_CONTEXT_LENGTH = 16384
+# 上下文最大长度（字符数），32k
+MAX_CONTEXT_LENGTH = 32768
 
 # 特殊文件处理规则
 SPECIAL_FILE_HANDLERS = {
@@ -261,7 +261,6 @@ class GitCommitGenerator:
         if file_diffs[0] == '':
             file_diffs = file_diffs[1:]
 
-        compressed_diffs: Dict[str, str] = {}
         total_len = 0
 
         # First, process special files and small files
@@ -358,11 +357,11 @@ class GitCommitGenerator:
             # 使用 -F - 从标准输入读取多行消息进行提交
             self._run_command(["git", "commit", "-F", "-"], input_=message_str)
             logger.success("Commit applied successfully!")
-            
+
             # Push if auto_push is enabled
             if self.auto_push:
                 self._push_changes()
-                
+
         except subprocess.CalledProcessError as e:
             logger.error(f"Failed to apply commit. Git output:\n{e.stdout}\n{e.stderr}")
 
@@ -372,11 +371,11 @@ class GitCommitGenerator:
             logger.debug("Pushing changes to remote repository...")
             # Get current branch name
             current_branch = self._run_command(["git", "rev-parse", "--abbrev-ref", "HEAD"])
-            
+
             # Push to origin with the current branch
             self._run_command(["git", "push", "origin", current_branch])
             logger.success(f"Successfully pushed changes to origin/{current_branch}")
-            
+
         except subprocess.CalledProcessError as e:
             logger.error(f"Failed to push changes. Git output:\n{e.stdout}\n{e.stderr}")
             raise
@@ -403,10 +402,10 @@ class GitCommitGenerator:
 
 @click.command()
 @click.option(
-    '--push', 
-    is_flag=True, 
-    default=False, 
-    help='Automatically push changes to remote repository after successful commit.'
+    '--push',
+    is_flag=True,
+    default=False,
+    help='Automatically push changes to remote repository after successful commit.',
 )
 def main(push: bool):
     """Generate git commit message and apply commit with optional auto-push."""

--- a/app/plugins/instant_view_generator/node.py
+++ b/app/plugins/instant_view_generator/node.py
@@ -60,7 +60,7 @@ class InstantViewResponse(BaseModel):
     page: Optional[TelegraphPageResult] = Field(
         default=None, description="Telegraph page information"
     )
-    content: Optional[List[Dict[str, Any]]] = Field(
+    content: List[Union[Dict[str, Any], str]] | None = Field(
         default=None, description="Telegraph page content nodes"
     )
     error: Optional[str] = Field(default=None, description="Error message if failed")


### PR DESCRIPTION
This commit introduces a new `ENABLE_TEST_MODE` setting to facilitate testing Dify API protocol and boundary conditions.

- When `ENABLE_TEST_MODE` is active, all Dify requests (except for commit message generation) will be forced to use `ForcedCommand.TEST`, returning a predefined response.
- This mode automatically disables `ENABLE_DEV_MODE` to prevent conflicts.

Additionally, the `MAX_CONTEXT_LENGTH` for the commit message generator has been increased from 16KB to 32KB.

- This enhancement allows the generator to process larger git diffs, improving its ability to generate messages for more substantial changes.

Other changes include:
- Updating `InstantViewResponse` content type to support string nodes, enhancing flexibility.
- Refactoring `FORCED_COMMAND_TYPE` to use `StrEnum` for improved type safety and readability.