### PR TITLE
feat(bot): enhance video handling and caption management with instant…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,11 +9,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `uv add <package>` - Add new dependency
 - `uv remove <package>` - Remove dependency
 
-### Code Quality & Testing
-- `black app/ -C -l 100` - Format code using Black formatter
-- `ruff check app/ --fix` - Run linting with Ruff
-- `uv run app/main.py` - Run the main Telegram bot application
-
 ## High-level Architecture
 
 This is a sophisticated Telegram bot that integrates with Dify Workflow for AI-powered responses. The architecture follows a modular service-oriented design:

--- a/app/plugins/001.collect_wiki.ipynb
+++ b/app/plugins/001.collect_wiki.ipynb
@@ -21,6 +21,7 @@
    "source": [
     "from bs4 import BeautifulSoup\n",
     "from IPython.display import JSON\n",
+    "\n",
     "useful_links = []\n",
     "\n",
     "# //table[@class='infobox vcard']//a[@rel='nofollow']\n",


### PR DESCRIPTION
… view support

This commit introduces several improvements to media handling in the Telegram bot:

- Added support for sending videos up to 2GB in local mode, with proper handling of WebM format limitations
- Implemented instant view functionality for long captions using the new try_send_as_instant_view service
- Enhanced fallback parser to better locate downloaded media files with improved pattern matching
- Added proper caption length validation and handling for media batches
- Updated documentation to reflect new video handling capabilities

The changes improve the bot's ability to handle large media files and provide better user experience for content with long descriptions.